### PR TITLE
Typo in docs: indnet -> indent

### DIFF
--- a/doc/textobj-indent.txt
+++ b/doc/textobj-indent.txt
@@ -85,7 +85,7 @@ and "_" means a space to indent)
 	  __...
 	  endif
 <
-More variants are also available.  See |textobj-indnet-mapping| for the
+More variants are also available.  See |textobj-indent-mapping| for the
 details.
 
 


### PR DESCRIPTION
This typo breaks the tag linking vim does in the help file.
