### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When using pathogen (or other plugin managers?) making the helptags
stores them in doc/tags which git reports as untracked content. Adding
this directory to the .gitignore file prevents this message from
showing.
